### PR TITLE
make the initialization and upgrade process more reliable and upgrade to 20161025

### DIFF
--- a/msys2/msys2.nuspec
+++ b/msys2/msys2.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>msys2</id>
     <title>MSYS2</title>
-    <version>20161025.0.0</version>
+    <version>20161025.0.1</version>
     <authors>Alexpux, martell, mingwandroid, elieux, renatosilva, niXman</authors>
     <owners>userzimmermann, petemounce</owners>
     <summary>A Cygwin-derived software distro for Windows using Arch Linux's Pacman</summary>

--- a/msys2/msys2.nuspec
+++ b/msys2/msys2.nuspec
@@ -4,7 +4,7 @@
   <metadata>
     <id>msys2</id>
     <title>MSYS2</title>
-    <version>20160921.0.3</version>
+    <version>20161025.0.0</version>
     <authors>Alexpux, martell, mingwandroid, elieux, renatosilva, niXman</authors>
     <owners>userzimmermann, petemounce</owners>
     <summary>A Cygwin-derived software distro for Windows using Arch Linux's Pacman</summary>

--- a/msys2/tools/chocolateyinstall.ps1
+++ b/msys2/tools/chocolateyinstall.ps1
@@ -8,17 +8,17 @@ $ErrorActionPreference = 'Stop';
 
 $packageName = 'msys2'
 
-$msysVersion = '20160921'
+$msysVersion = '20161025'
 
 $msys32DistName = "msys2-base-i686-$msysVersion"
 $msys64DistName = "msys2-base-x86_64-$msysVersion"
 
 $url = "http://repo.msys2.org/distrib/i686/$msys32DistName.tar.xz"
-$checksum = '7DA041072DC2F8A346803AFE4FF1E1977DD1E905'
+$checksum = '5D17FA53077A93A38A9AC0ACB8A03BF6C2FC32AD'
 $checksumType = 'SHA1'
 
 $url64 = "http://repo.msys2.org/distrib/x86_64/$msys64DistName.tar.xz"
-$checksum64 = '78B1738EB6049EFB693E3D1AA4502BCBE03B2964'
+$checksum64 = '05FD74A6C61923837DFFE22601C9014F422B5460'
 $checksumType64 = 'SHA1'
 
 $toolsDir = Split-Path -parent $MyInvocation.MyCommand.Definition

--- a/msys2/tools/chocolateyinstall.ps1
+++ b/msys2/tools/chocolateyinstall.ps1
@@ -101,7 +101,8 @@ Bash
 
 # do the upgrade by running $command until no more packages are
 # available (when --print no longer outputs any url).
-$command = 'pacman --noconfirm --noprogressbar -Syuu'
+# NB --ask=20 is needed to workaround https://github.com/Alexpux/MSYS2-packages/issues/1141
+$command = 'pacman --noconfirm --ask=20 --noprogressbar -Syuu'
 while (Bash "$command --print" | Select-String '^https?://' -Quiet) {
     Write-Host 'Upgrading MSYS2...'
     Bash $command


### PR DESCRIPTION
I was having trouble installing msys2:

```
==> default: Chocolatey v0.10.3                                                                                                                
==> default: Installing the following packages:                                                                                                
==> default: msys2                                                                                                                             
==> default: By installing you accept licenses for the packages.                                                                               
==> default: msys2 v20160719.1.1 [Approved]                                                                                                    
==> default: msys2 package files install completed. Performing other installation steps.                                                       
==> default: Adding 'C:\ProgramData\chocolatey\lib\msys2' to PATH...                                                                           
==> default: PATH environment variable does not have C:\ProgramData\chocolatey\lib\msys2 in it. Adding...                                      
==> default: Installing to 'C:\tools\msys64'                                                                                                   
==> default: Downloading msys2 64 bit                                                                                                          
==> default:   from 'http://repo.msys2.org/distrib/x86_64/msys2-base-x86_64-20160719.tar.xz'                                                   
==> default: Download of msys2-base-x86_64-20160719.tar.xz (44.82 MB) completed.                                                               
==> default: Hashes match.                                                                                                                     
==> default: Extracting C:\Users\vagrant\AppData\Local\Temp\msys2\20160719.1.1\msys2-base-x86_64-20160719.tar.xz to C:\tools...                
==> default: C:\tools                                                                                                                          
==> default:                                                                                                                                   
==> default: Extracting C:\tools\msys2-base-x86_64-20160719.tar to C:\tools...                                                                 
==> default: C:\tools                                                                                                                          
==> default:                                                                                                                                   
==> default: Adding 'C:\tools\msys64' to PATH...                                                                                               
==> default: PATH environment variable does not have C:\tools\msys64 in it. Adding...                                                          
==> default: Initializing MSYS2...                                                                                                             
==> default:                                                                                                                                   
==> default: Starting 'C:\tools\msys64\msys2.exe'...                                                                                           
==> default: Upgrading core system packages with 'pacman --noconfirm -Syuu'...                                                                 
==> default: Upgrading full system with 'pacman --noconfirm -Syuu'...                                                                          
==> default: Environment Vars (like PATH) have changed. Close/reopen your shell to                                                             
==> default:                                                                                                                                   
==> default:  see the changes (or in powershell/cmd.exe just type `refreshenv`).                                                               
==> default:  The install of msys2 was successful.                                                                                             
==> default:                                                                                                                                   
==> default:   Software installed to 'C:\tools'                                                                                                
==> default:                                                                                                                                   
==> default: Chocolatey installed 1/1 packages. 0 packages failed.                                                                             
==> default:  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).                                                         
==> default: :: Synchronizing package databases...                                                                                             
==> default:                                                                                                                                   
==> default: error: failed to update mingw32 (unable to lock database)                                                                         
==> default: error: failed to update mingw64 (unable to lock database)                                                                         
==> default: error: failed to update msys (unable to lock database)                                                                            
==> default: error: failed to synchronize any databases                                                                                        
==> default: error: failed to init transaction (unable to lock database)                                                                       
==> default: error: could not lock database: File exists                                                                                       
==> default:   if you're sure a package manager is not already                                                                                 
==> default:   running, you can remove /var/lib/pacman/db.lck                                                                                  
==> default: ERROR: bash execution failed with exit code 1                                                                                     
==> default: ERROR: at Bash, C:\vagrant\provision.ps1: line 300                                                                                
==> default: ERROR: at <ScriptBlock>, C:\vagrant\provision.ps1: line 308                                                                       
==> default: ERROR: at <ScriptBlock>, C:\tmp\vagrant-shell.ps1: line 41                                                                        
The following WinRM command responded with a non-zero exit status.                                                                             
Vagrant assumes that this means the command failed!                                                                                            
                                                                                                                                               
powershell -ExecutionPolicy Bypass -OutputFormat Text -file c:\tmp\vagrant-shell.ps1 provision.ps1                                             
                                                                                                                                               
Stdout from the command:                                                                                                                       
                                                                                                                                               
                                                                                                                                               
                                                                                                                                               
Stderr from the command:                                                                                                                       
                                                                                                                                               
```                                                                                                       

It turns out that the initialization (the first call to bash) was still running before the pacman system upgrade process was started, as you can see in this picture:

![image](https://cloud.githubusercontent.com/assets/43356/21072320/e749930c-beb5-11e6-9993-e14d42288336.png)

Also, there was not much visibility into the msys2 upgrade process, so this pull request also outputs the msys2 initialization and pacman upgrade messages to the therminal.

The upgrade process was also augmented to keep the upgrade going until no more packages are available to upgrade.

This also upgrades msys2 to 20161025.